### PR TITLE
Fix invalid repo generation on debian

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -10,7 +10,8 @@ when 'debian'
   include_recipe 'apt'
   apt_repository 'grafana' do
     repo = node['grafana']['use_unstable_repo'] ? 'grafana/testing' : 'grafana/stable'
-    uri "#{node['grafana']['repo_url']}/#{repo}/debian wheezy main"
+    uri "#{node['grafana']['repo_url']}/#{repo}/debian"
+    components ['wheezy', 'main']
     key "#{node['grafana']['repo_url']}/gpg.key"
     action :add
   end


### PR DESCRIPTION
This generated invalid repo configuration on debian as the components were included in the same string as the URL. I split them out to use the "components" parameter.